### PR TITLE
PCI-1906 fix a bug in the epub-parser

### DIFF
--- a/lib/epub-parser.js
+++ b/lib/epub-parser.js
@@ -72,7 +72,7 @@ EpubParser = (function () {
                     md5hash = require('crypto').createHash('md5').update(data).digest("hex");
 
                     zip = new jszip(data.toString('binary'), {binary: true, base64: false, checkCRC32: true});
-                    var containerData = extractText('META-INF/container.xml'); 
+                    var containerData = extractText('META-INF/container.xml');
                     parseEpub(containerData, function (err, epubData) {
 
                         if (err) return cb(err);
@@ -227,10 +227,11 @@ EpubParser = (function () {
                                 }
                             }
 
+                            // for each section in the JSON (ncx, navMap and navPoint) try to get it with the prefix then without the prefix
+                            ncx = ncxJSON[ncxPrefix + "ncx"] || ncxJSON["ncx"];
 
-                            ncx = ncxJSON[ncxPrefix + "ncx"];
-
-                            var navPoints = ncx[ncxPrefix + "navMap"][0][ncxPrefix + "navPoint"];
+                            var navMap = ncx[ncxPrefix + "navMap"] || ncx["navMap"];
+                            var navPoints = navMap[0][ncxPrefix + "navPoint"] || navMap[0]["navPoint"];
 
                             for (var i = 0; i < safeAccess(navPoints).length; i++) {
                                 processNavPoint(navPoints[i]);


### PR DESCRIPTION
   - When a the TOC (tox.ncx) has a namespace the XML was not parser
   properly. Now we get the JSON version of the XML we try to access the
   elements in the JSON both with prefix and without the prefix so we
   will be sure to get it.