### PR TITLE
PCI-2117 Book-service fail to read some books (Internal Server Error)

### DIFF
--- a/lib/epub-parser.js
+++ b/lib/epub-parser.js
@@ -291,6 +291,19 @@ EpubParser = (function () {
                     itemHashByHref[href] = itemlist[item];
                     itemHashById[id] = itemlist[item];
 
+                    /**
+                     * http://www.idpf.org/epub/20/spec/OPF_2.0.1_draft.htm#Section2.4
+                     *
+                     * "The spine element must include the toc attribute,
+                     * whose value is the the id attribute value of
+                     * the required NCX document declared in manifest"
+                     *
+                     * If the spine element doesn't include the toc attribure,
+                     * but the item with id="ncx" and href="toc.ncx" exists.
+                     */
+                    if (id === 'ncx' && href === 'toc.ncx' && !ncxId) {
+                        ncxId = 'ncx';
+                    }
                 }
                 var itemrefs = itemreflist;
 


### PR DESCRIPTION
# Book-service fail to read some books (Internal Server Error)

https://jomedia.atlassian.net/browse/PCI-2117

Fix situation when the spine element doesn't include the toc attribure, but the item with id=ncx and href=toc.ncx exists.